### PR TITLE
유데미 영상 변경 시, 자막 활성화 안되는 이슈 수정

### DIFF
--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -22,6 +22,7 @@ const Dom: TRANSLATING_DOM_INFO = {
   udemy: {
     domWrapperAttrs: ".captions-display--captions-container--1-aQJ",
     domAttrs: ".captions-display--captions-cue-text--ECkJu",
+    domAttrsSub: ".curriculum-item-view--content--3ABmp",
   },
   youtube: {
     domWrapperAttrs: ".ytp-caption-window-container",

--- a/src/content.ts
+++ b/src/content.ts
@@ -52,6 +52,7 @@ const observer = new MutationObserver(renderTranslatedElementAndSetObserver);
 
 const connectObserver = (element: Element) => {
   const observerOptions: MutationObserverInit = {
+    subtree: true,
     childList: true,
     attributes: true,
     characterData: true,
@@ -142,3 +143,4 @@ chrome.runtime.onMessage.addListener(
 );
 
 initialSetRenderClosedCaption();
+connectClosedCaptionSubObserver();


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 유데미 영상 변경 시, 자막 활성화 안되는 이슈를 수정합니다.

- 기타 참고 문서 : 

- [Mutation observer 설정 API MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe)

## 💻 Changes

초기 Dom 트래킹을 담당할 Udemy dom 정보를 추가했습니다. 6e94339

mutation observer subtree option 을 활성화합니다. 8fe4005
이와 더불어 초기 실행 함수로 subObserver 함수를 추가합니다.

(subtree option 은 해당 돔 하위의 변경점을 트래킹하는 옵션입니다.
차후 해당 option 을 사용하여 불필요한 dom 설정을 삭제하고자 합니다.)

## 🎥 ScreenShot or Video

<변경 전 동작>

https://user-images.githubusercontent.com/64253365/233673703-00475a10-0c20-4c0d-b092-aac268ef1bcd.mov


<변경 후 동작>

https://user-images.githubusercontent.com/64253365/233673970-f6759dff-d828-4af0-8862-5bfd85f8055d.mov

