### PR TITLE
Popup 로직 개선 - MVC 패턴 적용

### DIFF
--- a/public/popup.ts
+++ b/public/popup.ts
@@ -1,148 +1,27 @@
-import {
-  getSwitchValueInStorage,
-  setSwitchValueInStorage,
-  getFontSizeValueInStorage,
-  setFontSizeValueInStorage,
-  getTranslatedTargetLanguageInStorage,
-  setTranslatedTargetLanguageInStorage,
-} from "../src/api/storage";
-import {
-  sendMessageToContentRangeValue,
-  sendMessageToContentChangedLanguage,
-  sendMessageToContentIsActiveTranslation,
-} from "../src/api/message";
+import FontSliderView from "../src/view/popup/FontSliderView";
+import LanguageSelectView from "../src/view/popup/LanguageSelectorView";
+import TranslatingSwitchView from "../src/view/popup/TranslatingSwitchView";
+import LanguageSelectorButtonView from "../src/view/popup/LanguageSelectorButtonView";
 
-import FontSlider from "../src/view/FontSlider";
-import LanguageSelector from "../src/view/LanguageSelector";
-import LanguageSelectorButton from "../src/view/LanguageSelectorButton";
+import PopupModel from "../src/model/popup/PopupModel";
 
-import { isLanguage } from "../src/common/isLanguage";
+import PopupController from "../src/controller/popup/PopupController";
 
-import type { LanguageCode } from "../src/common/language.types";
+const fontSliderView = new FontSliderView();
+const languageSelectorView = new LanguageSelectView();
+const translatingSwitchView = new TranslatingSwitchView();
+const languageSelectorButtonView = new LanguageSelectorButtonView();
 
-const translationElement = document.getElementById(
-  "translate"
-) as HTMLInputElement;
+const popupModel = new PopupModel();
 
-const rangeElement = document.getElementById(
-  "font-size-range"
-) as HTMLInputElement;
-
-const rangeInputElement = document.querySelector(
-  'input[type="range"]'
-) as HTMLInputElement;
-
-const FontSliderInstance = new FontSlider(rangeElement);
-const LanguageSelectorInstance = new LanguageSelector();
-const LanguageSelectorButtonInstance = new LanguageSelectorButton();
-
-const languageSelectorWrapperElement =
-  LanguageSelectorInstance.getLanguageSelectorWrapperElement();
-const languageSelectorButtonElement =
-  LanguageSelectorButtonInstance.getLanguageSelectorButtonElement();
-
-const setInitialSwitchState = async () => {
-  const isChecked = await getSwitchValueInStorage();
-
-  if (typeof isChecked !== "boolean") return;
-
-  translationElement.checked = isChecked;
-};
-
-const setInitialFontRangeSlider = async () => {
-  const fontSize = await getFontSizeValueInStorage();
-
-  if (typeof fontSize !== "number") return;
-
-  FontSliderInstance.setRangeValue(String(fontSize));
-  FontSliderInstance.setFontRangeStyle(fontSize);
-};
-
-const setFontRangeStyleAndStorageValue = async (rangeValue: number) => {
-  await setFontSizeValueInStorage(rangeValue);
-
-  FontSliderInstance.setFontRangeStyle(rangeValue);
-};
-
-const setInitialLanguageSelectorValue = async () => {
-  const language = (await getTranslatedTargetLanguageInStorage()) ?? "ko";
-  const languageCode = isLanguage(language) ? language : "ko";
-
-  LanguageSelectorInstance.toggleCheckLanguage(languageCode);
-};
-
-const setInitialLanguageSelectorText = async () => {
-  const language = (await getTranslatedTargetLanguageInStorage()) ?? "ko";
-  const languageCode = isLanguage(language) ? language : "ko";
-
-  LanguageSelectorButtonInstance.setLanguageSelectorButtonText(languageCode);
-};
-
-languageSelectorWrapperElement.addEventListener("click", async (event) => {
-  const target = event.target as HTMLDivElement;
-  const selectedLangDataAttribute = target.dataset.lang;
-  const prevLanguageCode =
-    (await getTranslatedTargetLanguageInStorage()) ?? "ko";
-
-  if (selectedLangDataAttribute === prevLanguageCode) return;
-
-  if (prevLanguageCode) {
-    const validatedPrevLanguageCode: LanguageCode = isLanguage(prevLanguageCode)
-      ? prevLanguageCode
-      : "ko";
-
-    LanguageSelectorInstance.toggleCheckLanguage(validatedPrevLanguageCode);
-  }
-
-  if (selectedLangDataAttribute) {
-    const languageCode: LanguageCode = isLanguage(selectedLangDataAttribute)
-      ? selectedLangDataAttribute
-      : "ko";
-
-    LanguageSelectorInstance.toggleCheckLanguage(languageCode);
-
-    await setTranslatedTargetLanguageInStorage(languageCode);
-
-    LanguageSelectorButtonInstance.setLanguageSelectorButtonText(languageCode);
-
-    await sendMessageToContentChangedLanguage(languageCode);
-  }
-
-  LanguageSelectorInstance.toggleLanguageSelectorDisplay();
-});
-
-languageSelectorButtonElement.addEventListener(
-  "click",
-  LanguageSelectorInstance.toggleLanguageSelectorDisplay
+const popupController = new PopupController(
+  fontSliderView,
+  languageSelectorView,
+  translatingSwitchView,
+  languageSelectorButtonView,
+  popupModel
 );
 
-translationElement.addEventListener("click", async () => {
-  const isChecked = translationElement.checked;
-
-  await setSwitchValueInStorage(isChecked);
-  await sendMessageToContentIsActiveTranslation(isChecked);
-});
-
-rangeInputElement.addEventListener("input", async () => {
-  const rangeValue = Number(FontSliderInstance.getRangeValue());
-
-  await setFontRangeStyleAndStorageValue(rangeValue);
-  await sendMessageToContentRangeValue(rangeValue);
-});
-
-chrome.runtime.onMessage.addListener(async (request: { message: string }) => {
-  if (request.message === "toggle-translate") {
-    const isChecked = translationElement.checked;
-
-    translationElement.checked = !isChecked;
-
-    await setSwitchValueInStorage(!isChecked);
-    await sendMessageToContentIsActiveTranslation(!isChecked);
-  }
-});
-
-// when popup open set default switch state
-setInitialSwitchState();
-setInitialFontRangeSlider();
-setInitialLanguageSelectorText();
-setInitialLanguageSelectorValue();
+popupController.setInitialSwitchState();
+popupController.setInitialFontRangeSlider();
+popupController.setInitialLanguageSelectorAndButton();

--- a/src/controller/popup/PopupController.ts
+++ b/src/controller/popup/PopupController.ts
@@ -1,0 +1,125 @@
+import FontSliderView from "../../view/popup/FontSliderView";
+import LanguageSelectorView from "../../view/popup/LanguageSelectorView";
+import TranslatingSwitchView from "../../view/popup/TranslatingSwitchView";
+import LanguageSelectorButtonView from "../../view/popup/LanguageSelectorButtonView";
+
+import PopupModel from "../../model/popup/PopupModel";
+
+import {
+  sendMessageToContentRangeValue,
+  sendMessageToContentChangedLanguage,
+  sendMessageToContentIsActiveTranslation,
+} from "../../api/message";
+import { isLanguage } from "../../common/isLanguage";
+
+class PopupController {
+  fontSliderView: FontSliderView;
+  languageSelectorView: LanguageSelectorView;
+  translatingSwitchView: TranslatingSwitchView;
+  languageSelectorButtonView: LanguageSelectorButtonView;
+  popupModel: PopupModel;
+
+  constructor(
+    _fontSliderView: FontSliderView,
+    _languageSelectorView: LanguageSelectorView,
+    _translatingSwitchView: TranslatingSwitchView,
+    _languageSelectorButtonView: LanguageSelectorButtonView,
+    _popupModel: PopupModel
+  ) {
+    this.fontSliderView = _fontSliderView;
+    this.languageSelectorView = _languageSelectorView;
+    this.translatingSwitchView = _translatingSwitchView;
+    this.languageSelectorButtonView = _languageSelectorButtonView;
+    this.popupModel = _popupModel;
+
+    this.fontSliderView
+      .getFontSliderElement()
+      .addEventListener(
+        "input",
+        this.updateFontSliderAndSetLocalStorageAndSendMessage
+      );
+
+    this.translatingSwitchView
+      .getTranslatingSwitchElement()
+      .addEventListener(
+        "click",
+        this.updateTranslateLocalStorageAndSendMessage
+      );
+
+    this.languageSelectorButtonView
+      .getLanguageSelectorButtonElement()
+      .addEventListener(
+        "click",
+        this.languageSelectorView.toggleLanguageSelectorDisplay
+      );
+
+    this.languageSelectorView
+      .getLanguageSelector()
+      .addEventListener(
+        "click",
+        this.updateSelectedLanguageAndSetLocalStorageAndSendMessage
+      );
+  }
+
+  private updateFontSliderAndSetLocalStorageAndSendMessage = async () => {
+    const rangeValue = Number(this.fontSliderView.getFontSliderValue());
+
+    this.fontSliderView.updateFontSlider(rangeValue);
+
+    await this.popupModel.setFontSize(rangeValue);
+
+    await sendMessageToContentRangeValue(rangeValue);
+  };
+
+  private updateTranslateLocalStorageAndSendMessage = async () => {
+    const isChecked = this.translatingSwitchView.getTranslatingSwitchValue();
+
+    await this.popupModel.setSwitchValue(isChecked);
+
+    await sendMessageToContentIsActiveTranslation(isChecked);
+  };
+
+  private updateSelectedLanguageAndSetLocalStorageAndSendMessage = async (
+    event: MouseEvent
+  ) => {
+    const target = event.target as HTMLDivElement;
+    const selectedLanguage = target.dataset.lang;
+
+    if (!selectedLanguage || !isLanguage(selectedLanguage)) return;
+
+    this.languageSelectorButtonView.setLanguageSelectorButtonText(
+      selectedLanguage
+    );
+    this.languageSelectorView.updateLanguage(selectedLanguage);
+
+    await this.popupModel.setLanguageCode(selectedLanguage);
+
+    await sendMessageToContentChangedLanguage(selectedLanguage);
+  };
+
+  public setInitialSwitchState = async () => {
+    const isChecked = await this.popupModel.getSwitchValue();
+    this.translatingSwitchView.setTranslatingSwitchValue(isChecked);
+
+    await sendMessageToContentIsActiveTranslation(isChecked);
+  };
+
+  public setInitialFontRangeSlider = async () => {
+    const fontSize = await this.popupModel.getFontSize();
+
+    this.fontSliderView.updateFontSlider(fontSize);
+
+    await sendMessageToContentRangeValue(fontSize);
+  };
+
+  public setInitialLanguageSelectorAndButton = async () => {
+    const languageCode = await this.popupModel.getLanguageCode();
+
+    this.languageSelectorView.toggleCheckLanguage(languageCode);
+    this.languageSelectorButtonView.setLanguageSelectorButtonText(languageCode);
+
+    await sendMessageToContentChangedLanguage(languageCode);
+  };
+}
+
+export default PopupController;

--- a/src/model/popup/PopupModel.test.ts
+++ b/src/model/popup/PopupModel.test.ts
@@ -1,0 +1,47 @@
+import PopupModel from "./PopupModel";
+
+const PopupModelInstance = new PopupModel();
+
+describe("Model", () => {
+  test("The default font size should be set 25", async () => {
+    const fontSize = await PopupModelInstance.getFontSize();
+
+    expect(fontSize).toBe(25);
+  });
+
+  test("The font size should be set 30", async () => {
+    await PopupModelInstance.setFontSize(30);
+
+    const fontSize = await PopupModelInstance.getFontSize();
+
+    expect(fontSize).toBe(30);
+  });
+
+  test("The default switch value should be set false", async () => {
+    const switchValue = await PopupModelInstance.getSwitchValue();
+
+    expect(switchValue).toBe(false);
+  });
+
+  test("The default switch value should be set true", async () => {
+    await PopupModelInstance.setSwitchValue(true);
+
+    const switchValue = await PopupModelInstance.getSwitchValue();
+
+    expect(switchValue).toBe(true);
+  });
+
+  test("The default language code value should be set ko", async () => {
+    const languageCode = await PopupModelInstance.getLanguageCode();
+
+    expect(languageCode).toBe("ko");
+  });
+
+  test("The language code value should be set en", async () => {
+    await PopupModelInstance.setLanguageCode("en");
+
+    const languageCode = await PopupModelInstance.getLanguageCode();
+
+    expect(languageCode).toBe("en");
+  });
+});

--- a/src/model/popup/PopupModel.ts
+++ b/src/model/popup/PopupModel.ts
@@ -1,0 +1,46 @@
+import {
+  setSwitchValueInStorage,
+  getSwitchValueInStorage,
+  setFontSizeValueInStorage,
+  getFontSizeValueInStorage,
+  setTranslatedTargetLanguageInStorage,
+  getTranslatedTargetLanguageInStorage,
+} from "../../api/storage";
+import { isLanguage } from "../../common/isLanguage";
+
+import type { LanguageCode } from "../../common/language.types";
+
+class PopupModel {
+  public setFontSize = async (fontSize: number) => {
+    await setFontSizeValueInStorage(fontSize);
+  };
+
+  public getFontSize = async () => {
+    const fontSize = (await getFontSizeValueInStorage()) ?? 25;
+
+    return fontSize;
+  };
+
+  public setSwitchValue = async (value: boolean) => {
+    await setSwitchValueInStorage(value);
+  };
+
+  public getSwitchValue = async () => {
+    const isChecked = (await getSwitchValueInStorage()) ?? false;
+
+    return isChecked;
+  };
+
+  public setLanguageCode = async (languageCode: LanguageCode) => {
+    await setTranslatedTargetLanguageInStorage(languageCode);
+  };
+
+  public getLanguageCode = async () => {
+    const language = (await getTranslatedTargetLanguageInStorage()) ?? "ko";
+    const languageCode = isLanguage(language) ? language : "ko";
+
+    return languageCode;
+  };
+}
+
+export default PopupModel;

--- a/src/view/popup/FontSliderView.test.ts
+++ b/src/view/popup/FontSliderView.test.ts
@@ -1,0 +1,73 @@
+import FontSliderView from "./FontSliderView";
+
+const DEFAULT_RANGE_VALUE = "20";
+const DEFAULT_RANGE_MIN = "10";
+const DEFAULT_RANGE_MAX = "30";
+
+describe("Font Slider View Test", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input type="range" id="font-range" min=${DEFAULT_RANGE_MIN} max=${DEFAULT_RANGE_MAX} value=${DEFAULT_RANGE_VALUE} />
+    `;
+  });
+
+  it("The font slider view should be set to the target of translating element", () => {
+    const FontSliderViewInstance = new FontSliderView();
+    const currentFontSliderValue = FontSliderViewInstance.getFontSliderValue();
+    const FontSliderViewElement = FontSliderViewInstance.getFontSliderElement();
+
+    const FontRangeElement = document.getElementById(
+      "font-range"
+    ) as HTMLInputElement;
+
+    expect(FontRangeElement).toBe(FontSliderViewElement);
+    expect(currentFontSliderValue).toBe(DEFAULT_RANGE_VALUE);
+  });
+
+  it('The font slider element value should be "20"', () => {
+    const FontSliderViewInstance = new FontSliderView();
+    const FontSliderElement = FontSliderViewInstance.getFontSliderElement();
+
+    expect(FontSliderElement.value).toBe(DEFAULT_RANGE_VALUE);
+  });
+
+  it('The font slider element max value should be "30"', () => {
+    const FontSliderViewInstance = new FontSliderView();
+    const FontSliderElement = FontSliderViewInstance.getFontSliderElement();
+
+    expect(FontSliderElement.max).toBe(DEFAULT_RANGE_MAX);
+  });
+
+  it('The font slider element min value should be "10"', () => {
+    const FontSliderViewInstance = new FontSliderView();
+    const FontSliderElement = FontSliderViewInstance.getFontSliderElement();
+
+    expect(FontSliderElement.min).toBe(DEFAULT_RANGE_MIN);
+  });
+
+  it("The font slider element style and value should be set default value to the target of translating element", () => {
+    const FontSliderViewInstance = new FontSliderView();
+
+    FontSliderViewInstance.updateFontSlider(Number(DEFAULT_RANGE_VALUE));
+
+    const FontSliderValue = FontSliderViewInstance.getFontSliderValue();
+    const FontSliderElement = FontSliderViewInstance.getFontSliderElement();
+
+    expect(FontSliderValue).toBe(DEFAULT_RANGE_VALUE);
+    expect(FontSliderElement.style.backgroundSize).toBe("50% 100%");
+  });
+
+  it("The font slider element style and value should be set 25 value to the target of translating element", () => {
+    const CHANGED_RANGE_VALUE = "25";
+
+    const FontSliderViewInstance = new FontSliderView();
+
+    FontSliderViewInstance.updateFontSlider(Number(CHANGED_RANGE_VALUE));
+
+    const FontSliderValue = FontSliderViewInstance.getFontSliderValue();
+    const FontSliderElement = FontSliderViewInstance.getFontSliderElement();
+
+    expect(FontSliderValue).toBe(CHANGED_RANGE_VALUE);
+    expect(FontSliderElement.style.backgroundSize).toBe("75% 100%");
+  });
+});

--- a/src/view/popup/FontSliderView.test.ts
+++ b/src/view/popup/FontSliderView.test.ts
@@ -7,7 +7,7 @@ const DEFAULT_RANGE_MAX = "30";
 describe("Font Slider View Test", () => {
   beforeEach(() => {
     document.body.innerHTML = `
-      <input type="range" id="font-range" min=${DEFAULT_RANGE_MIN} max=${DEFAULT_RANGE_MAX} value=${DEFAULT_RANGE_VALUE} />
+      <input type="range" id="font-size-range" min=${DEFAULT_RANGE_MIN} max=${DEFAULT_RANGE_MAX} value=${DEFAULT_RANGE_VALUE} />
     `;
   });
 
@@ -17,7 +17,7 @@ describe("Font Slider View Test", () => {
     const FontSliderViewElement = FontSliderViewInstance.getFontSliderElement();
 
     const FontRangeElement = document.getElementById(
-      "font-range"
+      "font-size-range"
     ) as HTMLInputElement;
 
     expect(FontRangeElement).toBe(FontSliderViewElement);

--- a/src/view/popup/FontSliderView.ts
+++ b/src/view/popup/FontSliderView.ts
@@ -3,7 +3,7 @@ class FontSliderView {
 
   constructor() {
     this.sliderElement = document.getElementById(
-      "font-range"
+      "font-size-range"
     ) as HTMLInputElement;
   }
 

--- a/src/view/popup/FontSliderView.ts
+++ b/src/view/popup/FontSliderView.ts
@@ -1,0 +1,36 @@
+class FontSliderView {
+  private readonly sliderElement: HTMLInputElement;
+
+  constructor() {
+    this.sliderElement = document.getElementById(
+      "font-range"
+    ) as HTMLInputElement;
+  }
+
+  private setFontSliderValue = (value: string) => {
+    this.sliderElement.value = value;
+  };
+
+  private setFontSliderStyle = (value: number) => {
+    const min = Number(this.sliderElement.min);
+    const max = Number(this.sliderElement.max);
+
+    this.sliderElement.style.backgroundSize =
+      ((value - min) * 100) / (max - min) + "% 100%";
+  };
+
+  public getFontSliderElement = () => {
+    return this.sliderElement;
+  };
+
+  public getFontSliderValue = () => {
+    return this.sliderElement.value;
+  };
+
+  public updateFontSlider = (value: number) => {
+    this.setFontSliderStyle(value);
+    this.setFontSliderValue(value.toString());
+  };
+}
+
+export default FontSliderView;

--- a/src/view/popup/LanguageSelectorButtonView.test.ts
+++ b/src/view/popup/LanguageSelectorButtonView.test.ts
@@ -1,0 +1,60 @@
+import LanguageSelectorButtonView from "./LanguageSelectorButtonView";
+
+import type { LanguageCode } from "../../common/language.types";
+
+describe("Language Selector Button View Test", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button id="language-select-button" class="language_button">Korean</button>
+    `;
+  });
+
+  it("The language selector button should be set the language-selector-button id attribute", () => {
+    const LanguageSelectorButtonViewInstance = new LanguageSelectorButtonView();
+    const LanguageSelectorButtonViewElement =
+      LanguageSelectorButtonViewInstance.getLanguageSelectorButtonElement();
+
+    const LanguageSelectorButtonElement = document.getElementById(
+      "language-select-button"
+    ) as HTMLButtonElement;
+
+    expect(LanguageSelectorButtonViewElement).toBe(
+      LanguageSelectorButtonElement
+    );
+  });
+
+  it('The language selector button default value should be "Korean"', () => {
+    const LanguageSelectorButtonViewInstance = new LanguageSelectorButtonView();
+    const languageSelectorButtonValue =
+      LanguageSelectorButtonViewInstance.getLanguageSelectorButtonText();
+
+    expect(languageSelectorButtonValue).toBe("Korean");
+  });
+
+  it("The language selector button should be another language when button text changed", () => {
+    const LanguageSelectorButtonViewInstance = new LanguageSelectorButtonView();
+
+    const LANGUAGES: LanguageCode[] = ["de", "en", "es", "ja", "ko", "zh"];
+    const LANGUAGES_MAP: Map<LanguageCode, string> = new Map([
+      ["de", "German"],
+      ["ko", "Korean"],
+      ["en", "English"],
+      ["zh", "Chinese"],
+      ["es", "Spanish"],
+      ["de", "German"],
+      ["ja", "Japanese"],
+    ]);
+
+    LANGUAGES.forEach((language) => {
+      LanguageSelectorButtonViewInstance.setLanguageSelectorButtonText(
+        language
+      );
+
+      const currentLanguageSelectorButtonValue =
+        LanguageSelectorButtonViewInstance.getLanguageSelectorButtonText();
+      const currentFullNameLanguage = LANGUAGES_MAP.get(language);
+
+      expect(currentLanguageSelectorButtonValue).toBe(currentFullNameLanguage);
+    });
+  });
+});

--- a/src/view/popup/LanguageSelectorButtonView.ts
+++ b/src/view/popup/LanguageSelectorButtonView.ts
@@ -1,0 +1,50 @@
+import type { LanguageCode } from "../../common/language.types";
+
+class LanguageSelectorButtonView {
+  private readonly languageSelectorButton: HTMLButtonElement;
+
+  constructor() {
+    this.languageSelectorButton = document.getElementById(
+      "language-select-button"
+    ) as HTMLButtonElement;
+  }
+
+  public getLanguageSelectorButtonElement = () => {
+    return this.languageSelectorButton;
+  };
+
+  public getLanguageSelectorButtonText = () => {
+    return this.languageSelectorButton.textContent;
+  };
+
+  public setLanguageSelectorButtonText = (language: LanguageCode) => {
+    switch (language) {
+      case "ko": {
+        this.languageSelectorButton.textContent = "Korean";
+        break;
+      }
+      case "en": {
+        this.languageSelectorButton.textContent = "English";
+        break;
+      }
+      case "zh": {
+        this.languageSelectorButton.textContent = "Chinese";
+        break;
+      }
+      case "es": {
+        this.languageSelectorButton.textContent = "Spanish";
+        break;
+      }
+      case "de": {
+        this.languageSelectorButton.textContent = "German";
+        break;
+      }
+      case "ja": {
+        this.languageSelectorButton.textContent = "Japanese";
+        break;
+      }
+    }
+  };
+}
+
+export default LanguageSelectorButtonView;

--- a/src/view/popup/LanguageSelectorView.test.ts
+++ b/src/view/popup/LanguageSelectorView.test.ts
@@ -1,0 +1,180 @@
+import LanguageSelectView from "./LanguageSelectorView";
+
+describe("Language Selector View Test", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="language-controller" class="language_controller hidden">
+        <div data-lang="en" class="language_wrapper">
+          <p>English</p>
+          <svg
+            class="hidden"
+            fill="#ffffff"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="ko" class="language_wrapper">
+          <p>Korean</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="ja" class="language_wrapper">
+          <p>Japanese</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="zh" class="language_wrapper">
+          <p>Chinese</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="de" class="language_wrapper">
+          <p>German</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="es" class="language_wrapper">
+          <p>Spanish</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+      </div>
+    `;
+  });
+
+  it("The language selector should be set hidden element and language controller element", () => {
+    const LanguageSelectorViewInstance = new LanguageSelectView();
+
+    const languageSelectorElement = document.getElementById(
+      "language-controller"
+    ) as HTMLDivElement;
+    const selectedLanguageElement = document.querySelector(".selected");
+    const languageSelectorElementOfInstance =
+      LanguageSelectorViewInstance.getLanguageSelector();
+
+    /** The default state is No Element selected */
+    expect(selectedLanguageElement).toBeNull();
+    expect(languageSelectorElement).toBe(languageSelectorElementOfInstance);
+  });
+
+  it("The target language should have been checked when you first updated", () => {
+    const DEFAULT_LANGUAGE = "ko";
+
+    const LanguageSelectorViewInstance = new LanguageSelectView();
+
+    LanguageSelectorViewInstance.updateLanguage(DEFAULT_LANGUAGE);
+
+    const selectedLanguageElement = document.querySelector(".selected");
+    const targetLanguageElement = document.querySelector(
+      `[data-lang="${DEFAULT_LANGUAGE}"]`
+    ) as HTMLDivElement;
+    const targetLanguageSvgElement = targetLanguageElement.children[1];
+
+    expect(selectedLanguageElement).toBe(targetLanguageSvgElement);
+  });
+
+  it("Checking when to change from the default KO language to the EN language", () => {
+    const DEFAULT_LANGUAGE = "ko";
+    const CHANGED_LANGUAGE = "en";
+
+    const LanguageSelectorViewInstance = new LanguageSelectView();
+
+    /** Check value for initial KO */
+    LanguageSelectorViewInstance.updateLanguage(DEFAULT_LANGUAGE);
+
+    const defaultSelectedLanguageElement = document.querySelector(".selected");
+    const defaultTargetLanguageElement = document.querySelector(
+      `[data-lang="${DEFAULT_LANGUAGE}"]`
+    ) as HTMLDivElement;
+    const defaultTargetLanguageSvgElement =
+      defaultTargetLanguageElement.children[1];
+
+    expect(defaultTargetLanguageSvgElement).toBe(
+      defaultSelectedLanguageElement
+    );
+
+    /** Check value for changed EN */
+    LanguageSelectorViewInstance.updateLanguage(CHANGED_LANGUAGE);
+
+    const selectedLanguageElementOfChangedValue =
+      document.querySelector(".selected");
+    const changedTargetLanguageElement = document.querySelector(
+      `[data-lang="${CHANGED_LANGUAGE}"]`
+    ) as HTMLDivElement;
+    const changedTargetLanguageSvgElement =
+      changedTargetLanguageElement.children[1];
+
+    expect(changedTargetLanguageSvgElement).toBe(
+      selectedLanguageElementOfChangedValue
+    );
+  });
+});

--- a/src/view/popup/LanguageSelectorView.ts
+++ b/src/view/popup/LanguageSelectorView.ts
@@ -1,0 +1,42 @@
+import type { LanguageCode } from "../../common/language.types";
+
+class LanguageSelectView {
+  private readonly languageSelector: HTMLDivElement;
+
+  constructor() {
+    this.languageSelector = document.getElementById(
+      "language-controller"
+    ) as HTMLDivElement;
+  }
+
+  private updateSelectedLanguageStyle = (selectedElement: SVGElement) => {
+    selectedElement.classList.toggle("hidden");
+    selectedElement.classList.toggle("selected");
+  };
+
+  public getLanguageSelector = () => {
+    return this.languageSelector;
+  };
+
+  public toggleLanguageSelectorDisplay = () => {
+    // toggle 이 되면 이거 체크
+    this.languageSelector.classList.toggle("hidden");
+  };
+
+  public toggleCheckLanguage = (language: LanguageCode) => {
+    const targetLanguageElement = document.querySelector(
+      `[data-lang="${language}"]`
+    ) as HTMLDivElement;
+    const targetLanguageSvgElement = targetLanguageElement
+      .children[1] as SVGElement;
+
+    this.updateSelectedLanguageStyle(targetLanguageSvgElement);
+  };
+
+  public updateLanguage = (language: LanguageCode) => {
+    this.toggleCheckLanguage(language);
+    this.toggleLanguageSelectorDisplay();
+  };
+}
+
+export default LanguageSelectView;

--- a/src/view/popup/TranslatingSwitchView.test.ts
+++ b/src/view/popup/TranslatingSwitchView.test.ts
@@ -1,0 +1,39 @@
+import TranslatingSwitchView from "./TranslatingSwitchView";
+
+describe("Translating Switch View Test", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <label class="switch">
+        <input id="translate" type="checkbox" />
+        <span class="slider round"></span>
+      </label>  `;
+  });
+
+  it("The translating switch view should be set to the translate id element", () => {
+    const TranslatingSwitchViewInstance = new TranslatingSwitchView();
+    const SwitchViewElement =
+      TranslatingSwitchViewInstance.getTranslatingSwitchElement();
+    const TranslatingElement = document.getElementById("translate");
+
+    expect(SwitchViewElement).toBe(TranslatingElement);
+  });
+
+  it("The translating switch view default should be false", () => {
+    const TranslatingSwitchViewInstance = new TranslatingSwitchView();
+    const switchValue =
+      TranslatingSwitchViewInstance.getTranslatingSwitchValue();
+
+    expect(switchValue).toBe(false);
+  });
+
+  it("The translating switch view should be change true", () => {
+    const TranslatingSwitchViewInstance = new TranslatingSwitchView();
+
+    TranslatingSwitchViewInstance.setTranslatingSwitchValue(true);
+
+    const switchValue =
+      TranslatingSwitchViewInstance.getTranslatingSwitchValue();
+
+    expect(switchValue).toBe(true);
+  });
+});

--- a/src/view/popup/TranslatingSwitchView.ts
+++ b/src/view/popup/TranslatingSwitchView.ts
@@ -1,0 +1,23 @@
+class TranslatingSwitchView {
+  private readonly translatingSwitchElement: HTMLInputElement;
+
+  constructor() {
+    this.translatingSwitchElement = document.getElementById(
+      "translate"
+    ) as HTMLInputElement;
+  }
+
+  public getTranslatingSwitchElement = () => {
+    return this.translatingSwitchElement;
+  };
+
+  public getTranslatingSwitchValue = () => {
+    return this.translatingSwitchElement.checked;
+  };
+
+  public setTranslatingSwitchValue = (value: boolean) => {
+    this.translatingSwitchElement.checked = value;
+  };
+}
+
+export default TranslatingSwitchView;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : legacy popup 로직을 MVC 패턴을 적용하여 개선했습니다.
            이를 통해 기존 `popup.ts` 내에서 localStorage, send message, view handling 로직을
            겹쳐 사용하여 코드 가독성이 떨어지는 문제를 개선합니다.

- 기타 참고 문서 :

- [MVC 패턴이란? - MDN Docs](https://developer.mozilla.org/ko/docs/Glossary/MVC)
- [MVC 패턴 - 위키토피아](https://ko.wikipedia.org/wiki/%EB%AA%A8%EB%8D%B8-%EB%B7%B0-%EC%BB%A8%ED%8A%B8%EB%A1%A4%EB%9F%AC)
- [MVC 패턴이란? - 블로그 글 발췌](https://medium.com/@jang.wangsu/%EB%94%94%EC%9E%90%EC%9D%B8%ED%8C%A8%ED%84%B4-mvc-%ED%8C%A8%ED%84%B4%EC%9D%B4%EB%9E%80-1d74fac6e256)

## 💻 Changes

FontSlider 에 대한 View Class, Test 코드를 작성했습니다. 81834a4

Switch 에 대한 View Class, Test 코드를 작성했습니다. eb2324d

언어 선택 Button 에 대한 View Class, Test 코드를 작성했습니다. a6277d2

언어 Selector 에 대한 View Class, Test 코드를 작성했습니다. fb04c84

Popup 에서 사용할 데이터를 관리하는 Model Class, Test 코드를 작성했습니다. 5c23706

View, Model 을 핸들링하는 Popup Controller 의 비즈니스 코드 작성 및 popup.ts 에 적용했습니다. 68f0880

## 🎥 ScreenShot or Video

N/A

## 🧑‍💻 Next Step

- Controller Class 내 message passing 로직 분리 (테스트 용이성을 위해)
- Popup, Content Class 디렉토리 분리

현재 Controller 비즈니스 코드에 chrome message passing 로직이 있습니다.
이는 실제 해당 동작들과 함께 실행해야하는 것은 맞으나,
불확실성이 존재하는 동작으로 테스트 작성에 불편함을 줍니다.

chrome message passing 로직을 분리하여 Controller 비즈니스 코드의 순수성을 지키고
원래 목적인 View, Model 간의 중재자 역할을 잘하는지를 확인하려고 합니다.
