### PR TITLE
번역 언어 변경 시 자막이 깜빡이는 버그 수정

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -69,6 +69,10 @@ class Controller {
   }
 
   changeLanguageCodeElement(languageCode: LanguageCode) {
+    const translatedLanguageCode = this._model.getLanguageCode();
+
+    if (translatedLanguageCode === languageCode) return;
+
     this._model.setLanguageCode(languageCode);
     this._view.deleteClosedCaptionElement();
     this.translatedAndRender();


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 번역 언어 변경 시 자막이 깜빡이는 버그를 수정합니다.

- 기타 참고 문서 : N/A

## 💻 Changes

언어 변경 시 변경 전 언어와 동일하면 early return 합니다.
버그의 원인은 popup 이 켜질 때 initial logic 에 의해 changeLanguageCodeElement method 가
실행되는데 해당 method 는 존재하던 자막을 삭제한 후, 다시 보여주는 방식입니다.
이런 방식으로 인하여 popup 을 켤 때마다 깜빡이는 버그가 발생했습니다.

## 🎥 ScreenShot or Video

<table>
  <tr>
    <th> 변경 전 </th> <th> 변경 후 </th>
  </tr>
  <tr>
  <td>


https://user-images.githubusercontent.com/64253365/235708087-2e9ba3b0-1885-4f3e-bd81-3113348cf57b.mov



  </td>
  <td>


https://user-images.githubusercontent.com/64253365/235708402-25f82550-5dd6-4494-b332-951ed6597632.mov


  </td>
  </tr>
</table>
