### PR TITLE
Portuguese, Polish 언어 추가 

### DIFF
--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -1,0 +1,8 @@
+{
+  "name": {
+    "message": "closed caption - Podwójne napisy"
+  },
+  "description": {
+    "message": "Rozszerzenia do wyświetlania napisów w innych językach wraz z istniejącymi napisami"
+  }
+}

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "message": "closed caption - Legendas duplas"
+    "message": "legenda fechada - Legendas duplas"
   },
   "description": {
     "message": "Extensões para visualizar legendas noutras línguas juntamente com as legendas existentes"

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -1,0 +1,8 @@
+{
+  "name": {
+    "message": "closed caption - Legendas duplas"
+  },
+  "description": {
+    "message": "Extensões para visualizar legendas noutras línguas juntamente com as legendas existentes"
+  }
+}

--- a/public/popup.html
+++ b/public/popup.html
@@ -713,6 +713,23 @@
             />
           </svg>
         </div>
+        <div data-lang="pt" class="language_wrapper">
+          <p>Portuguese</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
       </div>
     </div>
     <footer class="footer">

--- a/public/popup.html
+++ b/public/popup.html
@@ -696,6 +696,23 @@
             />
           </svg>
         </div>
+        <div data-lang="pl" class="language_wrapper">
+          <p>Polish</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
       </div>
     </div>
     <footer class="footer">

--- a/src/common/isLanguage.ts
+++ b/src/common/isLanguage.ts
@@ -24,5 +24,6 @@ export const isLanguage = (language: string): language is LanguageCode => {
     "uk",
     "vi",
     "tr",
+    "pl",
   ].includes(language);
 };

--- a/src/common/isLanguage.ts
+++ b/src/common/isLanguage.ts
@@ -25,5 +25,6 @@ export const isLanguage = (language: string): language is LanguageCode => {
     "vi",
     "tr",
     "pl",
+    "pt",
   ].includes(language);
 };

--- a/src/common/language.types.ts
+++ b/src/common/language.types.ts
@@ -21,4 +21,5 @@ export type LanguageCode =
   | "uk"
   | "vi"
   | "tr"
-  | "pl";
+  | "pl"
+  | "pt";

--- a/src/common/language.types.ts
+++ b/src/common/language.types.ts
@@ -20,4 +20,5 @@ export type LanguageCode =
   | "th"
   | "uk"
   | "vi"
-  | "tr";
+  | "tr"
+  | "pl";

--- a/src/view/popup/LanguageSelectorButtonView.test.ts
+++ b/src/view/popup/LanguageSelectorButtonView.test.ts
@@ -58,6 +58,7 @@ describe("Language Selector Button View Test", () => {
       "vi",
       "tr",
       "pl",
+      "pt",
     ];
     const LANGUAGES_MAP: Map<LanguageCode, string> = new Map([
       ["de", "German"],
@@ -85,6 +86,7 @@ describe("Language Selector Button View Test", () => {
       ["vi", "Vietnamese"],
       ["tr", "Turkish"],
       ["pl", "Polish"],
+      ["pt", "Portuguese"],
     ]);
 
     LANGUAGES.forEach((language) => {

--- a/src/view/popup/LanguageSelectorButtonView.test.ts
+++ b/src/view/popup/LanguageSelectorButtonView.test.ts
@@ -57,6 +57,7 @@ describe("Language Selector Button View Test", () => {
       "uk",
       "vi",
       "tr",
+      "pl",
     ];
     const LANGUAGES_MAP: Map<LanguageCode, string> = new Map([
       ["de", "German"],
@@ -83,6 +84,7 @@ describe("Language Selector Button View Test", () => {
       ["uk", "Ukrainian"],
       ["vi", "Vietnamese"],
       ["tr", "Turkish"],
+      ["pl", "Polish"],
     ]);
 
     LANGUAGES.forEach((language) => {

--- a/src/view/popup/LanguageSelectorButtonView.ts
+++ b/src/view/popup/LanguageSelectorButtonView.ts
@@ -110,6 +110,10 @@ class LanguageSelectorButtonView extends PopupView {
         this.element.textContent = "Turkish";
         break;
       }
+      case "pl": {
+        this.element.textContent = "Polish";
+        break;
+      }
     }
   };
 }

--- a/src/view/popup/LanguageSelectorButtonView.ts
+++ b/src/view/popup/LanguageSelectorButtonView.ts
@@ -114,6 +114,10 @@ class LanguageSelectorButtonView extends PopupView {
         this.element.textContent = "Polish";
         break;
       }
+      case "pt": {
+        this.element.textContent = "Portuguese";
+        break;
+      }
     }
   };
 }


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : Portuguese, Polish 언어 추가합니다.

- 기타 참고 문서 : N/A

## 💻 Changes

Polish 언어를 popup html 에 추가합니다. 2532a22fe5045e53e4b2195c0ed6b53728e9177b

validation 함수에 pl language code 를 추가합니다. 8ebfc6b1db42f8a2a3488bf0f665de2ee187b076

language type 에 pl 를 추가합니다. ce2755a7dba21d8330cac150b8564c5cf03c5a3d

languageSelectorButtonView Class 에 pl language code 를 추가합니다. 53e22133c478936dde044eeb9a9e739ffbbadd12

Portuguese 언어를 html 에 추가합니다. 8625ae81392485a68814d0d83c508b6cdcdaa790

Portuguese 에 대한 validation 을 진행합니다. c9692fe76b08533cb7f8f68b329ccd7b8d4d6ae2

language type 에 pt 를 추가합니다. 8f66878a66e758287cac65c34dc3d75436f884ca

pt language code 를 languageSelectorButtonView class 에 추가합니다. 72ced8506aa0b732fd59f0e245e2bda20f4aedcc

## 🎥 ScreenShot or Video

N/A
